### PR TITLE
v2 samples on sam-pattern 2.1.2 (next-state contract) + v2 test harness

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -4,7 +4,9 @@
   "description": "Puppeteer smoke tests for SAM samples",
   "private": true,
   "scripts": {
-    "test": "node samples.test.js"
+    "test": "node samples.test.js && node v2.test.js",
+    "test:legacy": "node samples.test.js",
+    "test:v2": "node v2.test.js"
   },
   "dependencies": {
     "http-server": "^14.1.1",

--- a/tests/v2.test.js
+++ b/tests/v2.test.js
@@ -1,0 +1,381 @@
+/**
+ * Puppeteer smoke tests for the v2/ strict-profile samples (#20–#25).
+ *
+ * Three assertion layers per sample:
+ *   1. strict-error guard — interacting with the sample must not surface an
+ *      unexpected SamShapeError / SamFrameError / SamSchemaError (the failure
+ *      signature of a bad acceptor migration or a stale vendored build)
+ *   2. one functional assertion — the sample demonstrably *does something*
+ *      (the silent no-op is the failure family v2 exists to kill)
+ *   3. deliberate-failure demos asserted positively — a sample built to
+ *      demonstrate a strict-mode throw must still throw it
+ * Plus a node-side vendor-drift guard: v2/lib/SAM.js must be byte-identical
+ * to sam-lib/dist/SAM.js when a built dist is present.
+ *
+ * Run from the sam-samples/tests/ directory:
+ *   node v2.test.js
+ */
+
+const puppeteer = require('puppeteer')
+const httpServer = require('http-server')
+const path = require('path')
+const fs = require('fs')
+const assert = require('assert')
+
+// sam/ workspace root  (tests/ -> sam-samples/ -> sam/)
+const SERVE_ROOT = path.resolve(__dirname, '..', '..')
+let BASE_URL
+let server, browser, page
+let passed = 0, failed = 0, skipped = 0
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+async function setup() {
+  server = httpServer.createServer({ root: SERVE_ROOT, cache: -1, silent: true })
+  const port = await new Promise((resolve, reject) => {
+    server.server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => resolve(server.server.address().port))
+  })
+  BASE_URL = `http://localhost:${port}/sam-samples/v2`
+
+  browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-setuid-sandbox']
+  })
+}
+
+async function teardown() {
+  await browser.close()
+  server.close()
+}
+
+// opens a sample page and collects strict-profile errors from the console and
+// page errors — the layer-1 guard reads this after interacting
+async function openPage(sample, opts = {}) {
+  page = await browser.newPage()
+  const samErrors = []
+  const trap = (text) => {
+    if (/Sam(Shape|Frame|Schema)Error/.test(text)) samErrors.push(text)
+  }
+  page.on('console', (m) => trap(m.text()))
+  page.on('pageerror', (e) => trap(`${e.name}: ${e.message}`))
+  await page.goto(`${BASE_URL}/${sample}/index.html`, {
+    waitUntil: opts.waitUntil || 'networkidle0', timeout: 20000
+  })
+  return samErrors
+}
+
+async function closePage() {
+  if (page) { await page.close(); page = null }
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+// clicks every button on the page except deliberate failure demos
+async function clickAllButtons({ skipLabels = ['break'] } = {}) {
+  const buttons = await page.$$('button')
+  for (const b of buttons) {
+    const label = (await page.evaluate((el) => el.textContent || '', b)).toLowerCase()
+    if (skipLabels.some((s) => label.includes(s))) continue
+    try { await b.click({ delay: 5 }); await sleep(50) } catch { /* detached/hidden */ }
+  }
+  await sleep(120)
+}
+
+// clicks the first button whose text includes the label (for framework-rendered
+// buttons without ids)
+async function clickButtonByText(label) {
+  const clicked = await page.evaluate((text) => {
+    const b = [...document.querySelectorAll('button')]
+      .find((el) => (el.textContent || '').includes(text))
+    if (b) { b.click(); return true }
+    return false
+  }, label)
+  assert.ok(clicked, `no button with text "${label}"`)
+  await sleep(80)
+}
+
+// sets an input's value the framework-visible way (dispatches input event)
+async function typeInto(selector, value) {
+  await page.evaluate((sel, v) => {
+    const el = document.querySelector(sel)
+    el.value = v
+    el.dispatchEvent(new Event('input', { bubbles: true }))
+  }, selector, value)
+  await sleep(80)
+}
+
+const text = (selector) => page.$eval(selector, (el) => el.textContent.trim())
+
+function ok(label) {
+  console.log(`  ✓ ${label}`)
+  passed++
+}
+
+function fail(label, err) {
+  console.log(`  ✗ ${label}`)
+  console.log(`    ${err.message || err}`)
+  failed++
+}
+
+function skip(label, reason) {
+  console.log(`  - ${label} (skipped: ${reason})`)
+  skipped++
+}
+
+async function test(label, fn) {
+  try {
+    await fn()
+    ok(label)
+  } catch (err) {
+    fail(label, err)
+  } finally {
+    await closePage()
+  }
+}
+
+// asserts the layer-1 guard: no unexpected strict-profile errors surfaced
+const assertNoStrictErrors = (samErrors) => {
+  assert.strictEqual(samErrors.length, 0, `strict-profile errors: ${samErrors.join('; ')}`)
+}
+
+// ─── vendor-drift guard ─────────────────────────────────────────────────────
+
+function testVendorDrift() {
+  console.log('\nvendored lib (v2/lib/SAM.js)')
+  const vendored = path.resolve(__dirname, '..', 'v2', 'lib', 'SAM.js')
+  const dist = path.resolve(__dirname, '..', '..', 'sam-lib', 'dist', 'SAM.js')
+  try {
+    assert.ok(fs.existsSync(vendored), 'v2/lib/SAM.js missing')
+    if (!fs.existsSync(dist)) {
+      skip('matches sam-lib/dist/SAM.js', 'no built dist (standalone checkout or unbuilt sam-lib)')
+      return
+    }
+    assert.ok(
+      fs.readFileSync(vendored).equals(fs.readFileSync(dist)),
+      'v2/lib/SAM.js differs from sam-lib/dist/SAM.js — re-vendor: cp sam-lib/dist/SAM.js sam-samples/v2/lib/SAM.js'
+    )
+    ok('matches sam-lib/dist/SAM.js byte-for-byte')
+  } catch (err) {
+    fail('matches sam-lib/dist/SAM.js', err)
+  }
+}
+
+// ─── per-sample suites ──────────────────────────────────────────────────────
+
+async function testCounter() {
+  console.log('\n01-counter-vanilla')
+  await test('increments and survives all controls', async () => {
+    const errs = await openPage('01-counter-vanilla')
+    // #count renders empty until the first step commits
+    await page.click('#inc'); await sleep(80)
+    assert.strictEqual(await text('#count'), '1')
+    await clickAllButtons()
+    assertNoStrictErrors(errs)
+  })
+
+  await test('"Break it" demo still throws SamSchemaError (deliberate)', async () => {
+    await openPage('01-counter-vanilla')
+    await page.click('#break'); await sleep(150)
+    const log = await text('#log')
+    assert.ok(log.includes('SamSchemaError'), `expected SamSchemaError in log, got "${log}"`)
+  })
+}
+
+async function testTemperature() {
+  console.log('\n02-temperature-alpine')
+  await test('converts C to F through the strict step', async () => {
+    const errs = await openPage('02-temperature-alpine')
+    await typeInto('input[type=number]', '100')
+    await sleep(150)
+    const inputs = await page.$$eval('input[type=number]', (els) => els.map((e) => e.value))
+    assert.strictEqual(Number(inputs[1]), 212, `expected 212F, got ${inputs[1]}`)
+    assertNoStrictErrors(errs)
+  })
+}
+
+async function testStopwatch() {
+  console.log('\n03-stopwatch-vanjs')
+  await test('starts, ticks, laps, stops', async () => {
+    const errs = await openPage('03-stopwatch-vanjs')
+    await clickButtonByText('Start')
+    await sleep(400)
+    await clickButtonByText('Lap')
+    await clickButtonByText('Stop')
+    const body = await text('body')
+    assert.ok(!body.includes('0.0s') || body.match(/0\.[1-9]|[1-9]\.\d/),
+      'display never advanced past 0.0s')
+    assertNoStrictErrors(errs)
+  })
+}
+
+async function testRocket() {
+  console.log('\n04-rocket-launcher-lit')
+  await test('counts down after Start', async () => {
+    const errs = await openPage('04-rocket-launcher-lit')
+    const before = await text('.counter')
+    await clickButtonByText('Start')
+    await sleep(1400)
+    const after = await text('.counter')
+    assert.notStrictEqual(after, before, `counter stuck at ${before}`)
+    assertNoStrictErrors(errs)
+  })
+}
+
+async function testTodos() {
+  console.log('\n05-todos-preact')
+  await test('adds and toggles a todo', async () => {
+    const errs = await openPage('05-todos-preact')
+    await typeInto('input[name=title]', 'write the harness')
+    await clickButtonByText('Add')
+    await sleep(150)
+    const items = await page.$$('li')
+    assert.ok(items.length >= 1, 'todo was not added')
+    await page.click('li input[type=checkbox]'); await sleep(120)
+    const done = await page.$$('li.done')
+    assert.strictEqual(done.length, 1, 'toggle did not mark the todo done')
+    assertNoStrictErrors(errs)
+  })
+}
+
+async function testCrud() {
+  console.log('\n06-crud-vue')
+  await test('selecting a contact populates the form', async () => {
+    const errs = await openPage('06-crud-vue')
+    await sleep(200) // Vue mount
+    const rows = await page.$$('li')
+    assert.ok(rows.length >= 1, 'no seeded contacts rendered')
+    await rows[0].click(); await sleep(150)
+    const name = await page.$eval('input', (el) => el.value)
+    assert.ok(name.length > 0, 'Select did not populate the form')
+    assertNoStrictErrors(errs)
+  })
+}
+
+async function testWizard() {
+  console.log('\n07-wizard-petite-vue')
+  await test('Next advances the step', async () => {
+    const errs = await openPage('07-wizard-petite-vue')
+    await sleep(200) // petite-vue mount
+    const before = await text('.crumb.here')
+    await clickButtonByText('Next')
+    await sleep(150)
+    const after = await text('.crumb.here')
+    assert.notStrictEqual(after, before, `step stuck at ${before}`)
+    assertNoStrictErrors(errs)
+  })
+}
+
+async function testRating() {
+  console.log('\n08-rating-webcomponent')
+  await test('rating a component updates the average', async () => {
+    const errs = await openPage('08-rating-webcomponent')
+    await page.evaluate(() => {
+      const stars = document.querySelector('star-rating[name="yaml"]')
+        .shadowRoot.querySelectorAll('button')
+      stars[2].click() // rate 3
+    })
+    await sleep(150)
+    const summary = await text('#summary')
+    assert.ok(summary.includes('Average rating:'), `no average rendered: "${summary}"`)
+    assertNoStrictErrors(errs)
+  })
+}
+
+async function testSnake() {
+  console.log('\n09-snake-canvas')
+  await test('runs, turns, restarts', async () => {
+    const errs = await openPage('09-snake-canvas')
+    for (const key of ['ArrowDown', 'ArrowRight', 'ArrowUp']) {
+      await page.keyboard.press(key); await sleep(150)
+    }
+    await page.click('#restart'); await sleep(150)
+    assert.strictEqual(await text('#score'), 'Score: 0', 'restart did not reset the score')
+    assertNoStrictErrors(errs)
+  })
+}
+
+async function testRaft() {
+  console.log('\n10-raft-visualizer')
+  await test('timeout + two votes elects a leader', async () => {
+    const errs = await openPage('10-raft-visualizer')
+    assert.strictEqual(await text('#role'), 'follower')
+    await page.click('#timeout'); await sleep(100)
+    assert.strictEqual(await text('#role'), 'candidate', 'timeout did not start campaign')
+    await page.click('#vote2'); await sleep(100)
+    await page.click('#vote3'); await sleep(100)
+    assert.strictEqual(await text('#role'), 'leader', 'quorum did not elect')
+    assertNoStrictErrors(errs)
+  })
+
+  await test('stale heartbeat is rejected, not absorbed (deliberate)', async () => {
+    await openPage('10-raft-visualizer')
+    await page.click('#timeout'); await sleep(100)
+    await page.click('#hbLow'); await sleep(150)
+    // the rejection must be observable (steps log) and the role unchanged
+    assert.strictEqual(await text('#role'), 'candidate', 'stale heartbeat changed the role')
+    const steps = await text('#steps')
+    assert.ok(/reject|stale/i.test(steps), `no visible rejection in steps log: "${steps}"`)
+  })
+}
+
+async function testChecker() {
+  console.log('\n11-checker-playground')
+  await test('runs the checker off the instance manifest', async () => {
+    const errs = await openPage('11-checker-playground')
+    await page.click('#run')
+    await page.waitForFunction(
+      () => document.getElementById('out').textContent.trim().length > 0,
+      { timeout: 10000 }
+    )
+    const out = await text('#out')
+    assert.ok(out.length > 0, 'checker produced no output')
+    assertNoStrictErrors(errs)
+  })
+}
+
+async function testTimeTravel() {
+  console.log('\n12-time-travel-debugger')
+  await test('logs steps and travels back', async () => {
+    const errs = await openPage('12-time-travel-debugger')
+    const cartBefore = await page.$$eval('#cart div', (els) => els.length)
+    await page.click('#addDuck'); await sleep(100)
+    await page.click('#addBoat'); await sleep(100)
+    // the cart renders item rows plus a total row — assert relatively
+    const cartAfter = await page.$$eval('#cart div', (els) => els.length)
+    assert.strictEqual(cartAfter, cartBefore + 2, `expected ${cartBefore + 2} cart rows, got ${cartAfter}`)
+    const logRows = await page.$$('#log tr')
+    assert.ok(logRows.length >= 2, 'steps were not logged')
+    await logRows[0].click(); await sleep(150)
+    const cartBack = await page.$$eval('#cart div', (els) => els.length)
+    assert.ok(cartBack < cartAfter, `travel did not restore an earlier state (still ${cartBack} rows)`)
+    assertNoStrictErrors(errs)
+  })
+}
+
+// ─── runner ─────────────────────────────────────────────────────────────────
+
+async function run() {
+  testVendorDrift()
+  await setup()
+  try {
+    await testCounter()
+    await testTemperature()
+    await testStopwatch()
+    await testRocket()
+    await testTodos()
+    await testCrud()
+    await testWizard()
+    await testRating()
+    await testSnake()
+    await testRaft()
+    await testChecker()
+    await testTimeTravel()
+  } finally {
+    await teardown()
+  }
+  console.log(`\n${passed + failed + skipped} tests: ${passed} passed, ${failed} failed, ${skipped} skipped`)
+  process.exit(failed > 0 ? 1 : 0)
+}
+
+run().catch((err) => { console.error(err); process.exit(1) })

--- a/v2/01-counter-vanilla/index.html
+++ b/v2/01-counter-vanilla/index.html
@@ -63,11 +63,11 @@
         },
 
         acceptors: {
-          Increment: model => ({ by }) => {
-            model.count += by
+          Increment: model => ({ by }, { next }) => {
+            next.count = model.count + by
           },
-          Reset: model => () => {
-            model.count = 0
+          Reset: model => (proposal, { next }) => {
+            next.count = 0
           }
         }
       },

--- a/v2/02-temperature-alpine/index.html
+++ b/v2/02-temperature-alpine/index.html
@@ -70,16 +70,16 @@
           },
 
           acceptors: {
-            SetCelsius: model => ({ celsius }, { reject }) => {
+            SetCelsius: model => ({ celsius }, { reject, next }) => {
               if (Number.isNaN(celsius)) return reject('not a number')
               if (celsius < ABSOLUTE_ZERO_C) return reject(`${celsius}°C is below absolute zero`)
-              model.celsius = celsius
+              next.celsius = celsius
             },
-            SetFahrenheit: model => ({ fahrenheit }, { reject }) => {
+            SetFahrenheit: model => ({ fahrenheit }, { reject, next }) => {
               if (Number.isNaN(fahrenheit)) return reject('not a number')
               const celsius = toC(fahrenheit)
               if (celsius < ABSOLUTE_ZERO_C) return reject(`${fahrenheit}°F is below absolute zero`)
-              model.celsius = celsius
+              next.celsius = celsius
             }
           },
 

--- a/v2/03-stopwatch-vanjs/index.html
+++ b/v2/03-stopwatch-vanjs/index.html
@@ -58,28 +58,33 @@
         },
 
         acceptors: {
-          Start: model => ({ now }, { reject }) => {
+          Start: model => ({ now }, { reject, next, unchanged }) => {
             if (model.running) return reject('already running')
-            model.running = true
-            model.startedAt = now - model.elapsed
+            next.running = true
+            next.startedAt = now - model.elapsed
+            unchanged('*')
           },
-          Stop: model => ({ now }, { reject }) => {
+          Stop: model => ({ now }, { reject, next, unchanged }) => {
             if (!model.running) return reject('not running')
-            model.running = false
-            model.elapsed = now - model.startedAt
+            next.running = false
+            next.elapsed = now - model.startedAt
+            unchanged('*')
           },
-          Tick: model => ({ now }, { reject }) => {
+          Tick: model => ({ now }, { reject, next, unchanged }) => {
             if (!model.running) return reject('not running')
-            model.elapsed = now - model.startedAt
+            next.elapsed = now - model.startedAt
+            unchanged('*')
           },
-          Lap: model => ({ now }, { reject }) => {
+          Lap: model => ({ now }, { reject, next, unchanged }) => {
             if (!model.running) return reject('cannot lap a stopped watch')
-            model.laps = model.laps.concat(fmt(now - model.startedAt))
+            next.laps = model.laps.concat(fmt(now - model.startedAt))
+            unchanged('*')
           },
-          Reset: model => (proposal, { reject }) => {
+          Reset: model => (proposal, { reject, next, unchanged }) => {
             if (model.running) return reject('stop the watch first')
-            model.elapsed = 0
-            model.laps = []
+            next.elapsed = 0
+            next.laps = []
+            unchanged('*')
           }
         }
       },

--- a/v2/04-rocket-launcher-lit/index.html
+++ b/v2/04-rocket-launcher-lit/index.html
@@ -64,27 +64,31 @@
         },
 
         acceptors: {
-          Start: model => (p, { reject }) => {
+          Start: model => (p, { reject, next, unchanged }) => {
             if (model.status !== 'ready') return reject(`cannot start while ${model.status}`)
-            model.status = 'counting'
+            next.status = 'counting'
+            unchanged('*')
           },
-          Countdown: model => (p, { reject }) => {
+          Countdown: model => (p, { reject, next, unchanged }) => {
             if (model.status !== 'counting') return reject(`cannot count down while ${model.status}`)
             if (model.counter <= 0) return reject('countdown already complete')
-            model.counter -= 1
+            next.counter = model.counter - 1
+            unchanged('*')
           },
-          Launch: model => (p, { reject }) => {
+          Launch: model => (p, { reject, next, unchanged }) => {
             if (model.status !== 'counting' || model.counter > 0) return reject('launch conditions not met')
-            model.status = 'launched'
+            next.status = 'launched'
+            unchanged('*')
           },
-          Abort: model => (p, { reject }) => {
+          Abort: model => (p, { reject, next, unchanged }) => {
             if (model.status !== 'counting') return reject(`nothing to abort while ${model.status}`)
-            model.status = 'aborted'
+            next.status = 'aborted'
+            unchanged('*')
           },
-          Reset: model => (p, { reject }) => {
+          Reset: model => (p, { reject, next }) => {
             if (model.status === 'counting') return reject('abort first')
-            model.status = 'ready'
-            model.counter = COUNTDOWN
+            next.status = 'ready'
+            next.counter = COUNTDOWN
           }
         },
 

--- a/v2/05-todos-preact/index.html
+++ b/v2/05-todos-preact/index.html
@@ -102,19 +102,23 @@
         },
 
         acceptors: {
-          Add: model => ({ title, id }, { reject }) => {
+          Add: model => ({ title, id }, { reject, next, unchanged }) => {
             if (title.length === 0) return reject('title is blank')
-            model.todos = model.todos.concat({ id, title, done: false })
+            next.todos = model.todos.concat({ id, title, done: false })
+            unchanged('*')
           },
-          Toggle: model => ({ toggle }) => {
-            model.todos = model.todos.map(t => (t.id === toggle ? { ...t, done: !t.done } : t))
+          Toggle: model => ({ toggle }, { next, unchanged }) => {
+            next.todos = model.todos.map(t => (t.id === toggle ? { ...t, done: !t.done } : t))
+            unchanged('*')
           },
-          Remove: model => ({ remove }) => {
-            model.todos = model.todos.filter(t => t.id !== remove)
+          Remove: model => ({ remove }, { next, unchanged }) => {
+            next.todos = model.todos.filter(t => t.id !== remove)
+            unchanged('*')
           },
-          SetFilter: model => ({ filter }, { reject }) => {
+          SetFilter: model => ({ filter }, { reject, next, unchanged }) => {
             if (!['all', 'active', 'done'].includes(filter)) return reject(`unknown filter ${filter}`)
-            model.filter = filter
+            next.filter = filter
+            unchanged('*')
           }
         },
 

--- a/v2/06-crud-vue/index.html
+++ b/v2/06-crud-vue/index.html
@@ -104,28 +104,30 @@
         },
 
         acceptors: {
-          Create: model => ({ id, name, email }, { reject }) => {
+          Create: model => ({ id, name, email }, { reject, next }) => {
             if (!name.trim()) return reject('name is required')
             if (!email.includes('@')) return reject('email looks invalid')
-            model.contacts = model.contacts.concat({ id, name, email })
-            model.selectedId = id
+            next.contacts = model.contacts.concat({ id, name, email })
+            next.selectedId = id
           },
-          Update: model => ({ id, name, email }, { reject }) => {
+          Update: model => ({ id, name, email }, { reject, next, unchanged }) => {
             if (!model.contacts.some(c => c.id === id)) return reject(`no contact ${id}`)
             if (!name.trim()) return reject('name is required')
             if (!email.includes('@')) return reject('email looks invalid')
-            model.contacts = model.contacts.map(c => (c.id === id ? { id, name, email } : c))
+            next.contacts = model.contacts.map(c => (c.id === id ? { id, name, email } : c))
+            unchanged('*')
           },
-          Delete: model => ({ deleteId }, { reject }) => {
+          Delete: model => ({ deleteId }, { reject, next }) => {
             if (!model.contacts.some(c => c.id === deleteId)) return reject(`no contact ${deleteId}`)
-            model.contacts = model.contacts.filter(c => c.id !== deleteId)
-            model.selectedId = null
+            next.contacts = model.contacts.filter(c => c.id !== deleteId)
+            next.selectedId = null
           },
-          Select: model => ({ selectId }, { reject }) => {
+          Select: model => ({ selectId }, { reject, next, unchanged }) => {
             if (selectId !== null && !model.contacts.some(c => c.id === selectId)) {
               return reject(`no contact ${selectId}`)
             }
-            model.selectedId = selectId
+            next.selectedId = selectId
+            unchanged('*')
           }
         }
       }

--- a/v2/07-wizard-petite-vue/index.html
+++ b/v2/07-wizard-petite-vue/index.html
@@ -108,32 +108,35 @@
           },
 
           acceptors: {
-            SetQuantity: model => ({ quantity }, { reject }) => {
+            SetQuantity: model => ({ quantity }, { reject, next, unchanged }) => {
               if (!Number.isInteger(quantity) || quantity < 0) return reject('quantity must be a whole number ≥ 0')
-              model.quantity = quantity
+              next.quantity = quantity
+              unchanged('*')
             },
-            SetAddress: model => ({ address }) => { model.address = address },
-            SetCard: model => ({ card }) => { model.card = card },
+            SetAddress: model => ({ address }, { next, unchanged }) => { next.address = address; unchanged('*') },
+            SetCard: model => ({ card }, { next, unchanged }) => { next.card = card; unchanged('*') },
 
-            Next: model => (p, { reject }) => {
+            Next: model => (p, { reject, next, unchanged }) => {
               // per-step guards: the reasons a step refuses to advance
               if (model.step === 'cart' && model.quantity === 0) return reject('cart is empty — add at least one duck')
               if (model.step === 'shipping' && model.address.trim().length < 8) return reject('address looks too short')
               if (model.step === 'payment' && !/^\d{16}$/.test(model.card.replace(/\s/g, ''))) return reject('card number must be 16 digits')
               if (model.step === 'confirmed') return reject('order already confirmed')
-              model.step = STEPS[STEPS.indexOf(model.step) + 1]
+              next.step = STEPS[STEPS.indexOf(model.step) + 1]
+              unchanged('*')
             },
-            Back: model => (p, { reject }) => {
+            Back: model => (p, { reject, next, unchanged }) => {
               if (model.step === 'cart') return reject('already at the first step')
               if (model.step === 'confirmed') return reject('order already confirmed')
-              model.step = STEPS[STEPS.indexOf(model.step) - 1]
+              next.step = STEPS[STEPS.indexOf(model.step) - 1]
+              unchanged('*')
             },
-            Restart: model => (p, { reject }) => {
+            Restart: model => (p, { reject, next }) => {
               if (model.step !== 'confirmed') return reject('nothing to restart')
-              model.step = 'cart'
-              model.quantity = 1
-              model.address = ''
-              model.card = ''
+              next.step = 'cart'
+              next.quantity = 1
+              next.address = ''
+              next.card = ''
             }
           }
         },

--- a/v2/08-rating-webcomponent/index.html
+++ b/v2/08-rating-webcomponent/index.html
@@ -86,12 +86,12 @@
             },
 
             acceptors: {
-              Rate: model => ({ value }, { reject }) => {
+              Rate: model => ({ value }, { reject, next }) => {
                 if (!Number.isInteger(value) || value < 0 || value > MAX) {
                   return reject(`rating must be an integer between 0 and ${MAX}`)
                 }
                 // clicking the current rating clears it
-                model.value = value === model.value ? 0 : value
+                next.value = value === model.value ? 0 : value
               }
             }
           },

--- a/v2/09-snake-canvas/index.html
+++ b/v2/09-snake-canvas/index.html
@@ -83,31 +83,34 @@
         },
 
         acceptors: {
-          Turn: model => ({ direction }, { reject }) => {
+          Turn: model => ({ direction }, { reject, next, unchanged }) => {
             if (!model.alive) return reject('game over — restart to play')
             if (!DELTA[direction]) return reject(`unknown direction ${direction}`)
             if (direction === OPPOSITE[model.direction]) return reject('cannot reverse into yourself')
-            model.direction = direction
+            next.direction = direction
+            unchanged('*')
           },
-          Tick: model => ({ nextFood }, { reject }) => {
+          Tick: model => ({ nextFood }, { reject, next, unchanged }) => {
             if (!model.alive) return reject('game over')
             const [dx, dy] = DELTA[model.direction]
             const head = [model.body[0][0] + dx, model.body[0][1] + dy]
             const hitWall = head[0] < 0 || head[0] >= GRID || head[1] < 0 || head[1] >= GRID
             const hitSelf = model.body.some(([x, y]) => x === head[0] && y === head[1])
             if (hitWall || hitSelf) {
-              model.alive = false
+              next.alive = false
+              unchanged('*')
               return
             }
             const ate = head[0] === model.food[0] && head[1] === model.food[1]
-            model.body = [head, ...(ate ? model.body : model.body.slice(0, -1))]
+            next.body = [head, ...(ate ? model.body : model.body.slice(0, -1))]
             if (ate) {
-              model.score += 10
-              model.food = nextFood
+              next.score = model.score + 10
+              next.food = nextFood
             }
+            unchanged('*')
           },
-          Restart: model => ({ restart }) => {
-            Object.assign(model, restart)
+          Restart: model => ({ restart }, { next }) => {
+            Object.assign(next, restart)
           }
         }
       },

--- a/v2/10-raft-visualizer/index.html
+++ b/v2/10-raft-visualizer/index.html
@@ -100,24 +100,25 @@
         },
 
         acceptors: {
-          ElectionTimeout: model => (p, { reject }) => {
+          ElectionTimeout: model => (p, { reject, next }) => {
             if (model.role === 'leader') return reject('leaders do not time out')
-            model.role = 'candidate'
-            model.term += 1
-            model.votedFor = 'n1'
-            model.votesGranted = 1
+            next.role = 'candidate'
+            next.term = model.term + 1
+            next.votedFor = 'n1'
+            next.votesGranted = 1
           },
-          VoteGranted: model => (p, { reject }) => {
+          VoteGranted: model => (p, { reject, next, unchanged }) => {
             if (model.role !== 'candidate') return reject('votes only count while campaigning')
-            model.votesGranted += 1
-            if (model.votesGranted >= 2) model.role = 'leader'
+            next.votesGranted = model.votesGranted + 1
+            next.role = next.votesGranted >= 2 ? 'leader' : model.role
+            unchanged('term', 'votedFor')
           },
-          Heartbeat: model => ({ term }, { reject }) => {
+          Heartbeat: model => ({ term }, { reject, next }) => {
             if (term < model.term) return reject(`stale term ${term} < ${model.term}`)
-            model.role = 'follower'
-            model.term = term
-            model.votedFor = null
-            model.votesGranted = 0
+            next.role = 'follower'
+            next.term = term
+            next.votedFor = null
+            next.votesGranted = 0
           }
         }
       },

--- a/v2/11-checker-playground/index.html
+++ b/v2/11-checker-playground/index.html
@@ -73,14 +73,14 @@
             }
           },
           acceptors: {
-            Deposit: model => ({ deposit }) => {
-              model.balance += deposit
+            Deposit: model => ({ deposit }, { next }) => {
+              next.balance = model.balance + deposit
             },
-            Withdraw: model => ({ withdraw }, { reject }) => {
+            Withdraw: model => ({ withdraw }, { reject, next }) => {
               if (guarded && withdraw > model.balance) {
                 return reject(`insufficient funds: ${withdraw} > ${model.balance}`)
               }
-              model.balance -= withdraw
+              next.balance = model.balance - withdraw
             }
           }
         },

--- a/v2/12-time-travel-debugger/index.html
+++ b/v2/12-time-travel-debugger/index.html
@@ -86,18 +86,21 @@
         },
 
         acceptors: {
-          Add: model => ({ name, price }, { reject }) => {
+          Add: model => ({ name, price }, { reject, next, unchanged }) => {
             if (model.items.length >= 6) return reject('cart is full (6 items max)')
-            model.items = model.items.concat({ name, price })
+            next.items = model.items.concat({ name, price })
+            unchanged('discount')
           },
-          RemoveLast: model => (p, { reject }) => {
+          RemoveLast: model => (p, { reject, next, unchanged }) => {
             if (model.items.length === 0) return reject('cart is already empty')
-            model.items = model.items.slice(0, -1)
+            next.items = model.items.slice(0, -1)
+            unchanged('discount')
           },
-          Coupon: model => (p, { reject }) => {
+          Coupon: model => (p, { reject, next, unchanged }) => {
             if (model.discount > 0) return reject('coupon already applied')
             if (model.items.length < 2) return reject('coupon needs at least 2 items')
-            model.discount = 5
+            next.discount = 5
+            unchanged('items')
           }
         },
 

--- a/v2/lib/SAM.js
+++ b/v2/lib/SAM.js
@@ -1195,7 +1195,24 @@
       if (checkForOutOfOrder(proposal)) {
         beginStep(proposal);
         // accept proposal (synchronously, so strict-profile errors propagate)
-        acceptors.forEach(acceptSync(proposal, stepApi));
+        const acceptResults = acceptors.map(acceptSync(proposal, stepApi));
+
+        // async acceptors on a non-synchronized instance are a silent-loss bug:
+        // the step commits before the awaited body runs, so next-state writes
+        // land in a draft that the next step discards. Throw in next-state mode
+        // (construction over convention), warn otherwise. Use synchronize: true
+        // for async acceptors.
+        if (acceptResults.some(result => result && typeof result.then === 'function')) {
+          if (nextStateMode) {
+            throw new SamFrameError("async acceptor on a non-synchronized instance: next-state writes after an await are discarded \u2014 pass createInstance({ synchronize: true }) or make the acceptor synchronous (intent '".concat(currentIntentName, "')"), {
+              asyncAcceptor: true,
+              intent: currentIntentName
+            });
+          }
+          if (devWarnings) {
+            console.warn("SAM: acceptor returned a promise on a non-synchronized instance (intent '".concat(currentIntentName, "') \u2014 writes after an await land outside the step; use synchronize: true for async acceptors"));
+          }
+        }
 
         // v2 (#25): commit the next-state draft atomically after all acceptors
         commitNextState(proposal);

--- a/v2/lib/SAM.js
+++ b/v2/lib/SAM.js
@@ -1939,6 +1939,7 @@
     SamSchemaError,
     SamShapeError,
     SamValidationError,
+    SamFrameError,
     validateProposal,
     checkShapeWrite
   };

--- a/v2/lib/SAM.js
+++ b/v2/lib/SAM.js
@@ -456,6 +456,25 @@
   }
 
   /**
+   * Error thrown (strict mode, #25) when an acceptor step violates the next-state
+   * frame: a declared variable is neither assigned in `next` nor declared
+   * `unchanged`, or a variable is assigned by more than one acceptor in a single
+   * step (double-prime). Mirrors TLA+'s rule that every variable's prime must be
+   * constrained exactly once per step.
+   */
+  class SamFrameError extends Error {
+    /**
+     * @param {string} message - human-readable frame violation
+     * @param {Object} [details] - structured fields, e.g. { unaccounted } or { doublePrime }
+     */
+    constructor(message, details = {}) {
+      super(message);
+      this.name = 'SamFrameError';
+      Object.assign(this, details);
+    }
+  }
+
+  /**
    * Error thrown (strict mode) when instance.validate() finds obligations the
    * spec has not declared (missing schemas, domains, or model shape).
    */
@@ -606,7 +625,7 @@
 
   // errors the strict profile lets propagate to the intent caller rather than
   // converting to an __error proposal
-  const isStrictError = err => err.name === 'SamSchemaError' || err.name === 'SamShapeError';
+  const isStrictError = err => err.name === 'SamSchemaError' || err.name === 'SamShapeError' || err.name === 'SamFrameError';
 
   // v2 (#20): named intents — component.actions may be an object map of
   // name -> action | { action, schema, domain }. Normalizes to an array of
@@ -694,6 +713,14 @@
       stepDeepChange = false;
       stepBeforeSnapshot = strict && currentIntentName != null ? display(model) : undefined;
       stepErrorBefore = model.__error;
+      // v2 (#25): reset the next-state draft and its bookkeeping
+      if (nextStateMode) {
+        Object.keys(nextDraft).forEach(key => delete nextDraft[key]);
+        stepPrimed.clear();
+        stepUnchanged.clear();
+        stepAssignOrigin.clear();
+        stepUnchangedResolved = [];
+      }
     };
 
     // strict mode hands acceptors/reactors/naps a sealed view of the model:
@@ -725,8 +752,183 @@
         return true;
       }
     }) : model;
+
+    // v2 (#25): explicit next-state (prime) semantics. Active only in the strict
+    // profile once a modelShape is declared (it is the variable set primes range
+    // over). Acceptors receive `model` as a frozen pre-state (unprimed) and write
+    // to a `next` draft (primed); the draft commits atomically after all acceptors
+    // run, with an explicit-frame check (every variable assigned or `unchanged`).
+    let nextStateMode = false;
+    const nextDraft = {};
+    const stepPrimed = new Map(); // key -> { from, to }
+    const stepUnchanged = new Set(); // names (or '*') passed to unchanged()
+    let stepUnchangedResolved = []; // concrete variables held unchanged this step
+    const stepAssignOrigin = new Map(); // key -> acceptor id that assigned it (double-prime guard)
+    let nextAcceptorId = 0;
+
+    // v2 (#25): per-acceptor prime/frame accumulation for manifest(). Attribution
+    // is structural (each next.<var> write and unchanged() call is tagged with the
+    // acceptor that made it), not body-parsing; it accrues as acceptors run and
+    // converges under domain exploration. Keyed acceptors report under their intent
+    // name; broadcast/array acceptors aggregate under '*'. Each acceptor gets its
+    // own draft proxy/unchanged fn CLOSED OVER its id (not a shared mutable
+    // current-id), so attribution survives awaits in async acceptor bodies.
+    const acceptorMeta = {}; // key -> { primes:Set, unchanged:Set, unchangedAll:bool }
+    const acceptorKeyById = new Map(); // acceptor id -> key ('*' for broadcast/array)
+    const acceptorApiById = new Map(); // acceptor id -> { next, unchanged } bound to that id
+
+    // the frozen pre-state handed to acceptors: reads pass through to the (not-yet
+    // -committed) model; any write to a declared/observable key throws, forcing
+    // authors to assign `next.<var>` instead of mutating in place
+    const frozenModel = new Proxy(model, {
+      get(target, prop) {
+        const value = target[prop];
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+      set(target, prop, value) {
+        if (typeof prop === 'string' && prop.indexOf('__') !== 0) {
+          throw new SamShapeError(prop, "cannot write '".concat(prop, "' on the frozen pre-state; assign next.").concat(prop, " instead (#25)"));
+        }
+        target[prop] = value;
+        return true;
+      },
+      deleteProperty(target, prop) {
+        if (typeof prop === 'string' && prop.indexOf('__') !== 0) {
+          throw new SamShapeError(prop, "cannot delete '".concat(prop, "' on the frozen pre-state; assign next.").concat(prop, " instead (#25)"));
+        }
+        delete target[prop];
+        return true;
+      }
+    });
+
+    // the write-only `next` draft, bound to one acceptor id: shape-checked like
+    // sealedModel, records the primed value, and rejects a second acceptor
+    // priming an already-primed key. All bound proxies share the one nextDraft
+    // target — the id only drives attribution and the double-prime guard.
+    const makeNextProxy = id => new Proxy(nextDraft, {
+      set(target, prop, value) {
+        if (typeof prop === 'string' && prop.indexOf('__') !== 0) {
+          const violation = checkShapeWrite(modelShape, prop, value);
+          if (violation) {
+            throw new SamShapeError(prop, violation);
+          }
+          const origin = stepAssignOrigin.get(prop);
+          if (origin !== undefined && origin !== id) {
+            throw new SamFrameError("double-prime: variable '".concat(prop, "' assigned by more than one acceptor in a single step"), {
+              doublePrime: prop
+            });
+          }
+          stepAssignOrigin.set(prop, id);
+          if (stepPrimed.has(prop)) {
+            stepPrimed.get(prop).to = value;
+          } else {
+            stepPrimed.set(prop, {
+              from: model[prop],
+              to: value
+            });
+          }
+          const key = acceptorKeyById.get(id);
+          if (key && acceptorMeta[key]) {
+            acceptorMeta[key].primes.add(prop);
+          }
+        }
+        target[prop] = value;
+        return true;
+      }
+    });
+
+    // records variables the step deliberately leaves at their pre-state value;
+    // unchanged('*') frames all remaining unmentioned variables. Unknown names
+    // throw: a typo'd unchanged('rolle') must not silently fail to frame 'role'
+    const makeUnchanged = id => (...names) => {
+      const key = acceptorKeyById.get(id);
+      names.forEach(name => {
+        if (name !== '*' && modelShape && modelShape[name] === undefined) {
+          throw new SamFrameError("unchanged('".concat(name, "') does not match any declared modelShape variable (#25)"), {
+            unknown: name
+          });
+        }
+        stepUnchanged.add(name);
+        if (key && acceptorMeta[key]) {
+          if (name === '*') {
+            acceptorMeta[key].unchangedAll = true;
+          } else {
+            acceptorMeta[key].unchanged.add(name);
+          }
+        }
+      });
+    };
+    const registerAcceptorMeta = (id, key) => {
+      acceptorKeyById.set(id, key);
+      acceptorApiById.set(id, {
+        next: makeNextProxy(id),
+        unchanged: makeUnchanged(id)
+      });
+      if (!acceptorMeta[key]) {
+        acceptorMeta[key] = {
+          primes: new Set(),
+          unchanged: new Set(),
+          unchangedAll: false
+        };
+      }
+    };
+
+    // hands the acceptor its id-bound next/unchanged so prime attribution and the
+    // double-prime guard hold even when an async acceptor writes after an await
+    const asAcceptor = (id, fn) => (proposal, api) => {
+      if (!nextStateMode) {
+        return fn(proposal, api);
+      }
+      return fn(proposal, {
+        ...api,
+        ...acceptorApiById.get(id)
+      });
+    };
+
+    // commits the next-state draft atomically after all acceptors run: enforces
+    // the explicit frame (throws SamFrameError on an unaccounted variable) then
+    // applies the primed values through sealedModel so mutation tracking holds
+    const commitNextState = proposal => {
+      if (!nextStateMode || proposal.__error || currentIntentName == null || stepRejections.length > 0) {
+        return;
+      }
+      const assigned = Object.keys(nextDraft);
+      const explicitAll = stepUnchanged.has('*');
+      // derived variables are reactor-owned; they are not part of the acceptor frame
+      const obligation = Object.keys(modelShape).filter(key => !modelShape[key].derived);
+      const missing = obligation.filter(key => !assigned.includes(key) && !stepUnchanged.has(key) && !explicitAll);
+      if (missing.length > 0) {
+        // an entirely empty frame is the unhandled-intent signature — a fired
+        // intent no acceptor constrained; diagnose it as such rather than
+        // listing every variable
+        if (assigned.length === 0 && stepUnchanged.size === 0) {
+          throw new SamFrameError("next-state frame empty for intent '".concat(currentIntentName, "': no acceptor assigned next.<var> or declared unchanged(...) \u2014 unhandled intent or missing frame (#25)"), {
+            unaccounted: missing,
+            unhandledIntent: currentIntentName
+          });
+        }
+        throw new SamFrameError("next-state frame incomplete: variable(s) ".concat(missing.map(k => "'".concat(k, "'")).join(', '), " neither assigned in next nor declared unchanged (#25)"), {
+          unaccounted: missing
+        });
+      }
+      stepUnchangedResolved = obligation.filter(key => !assigned.includes(key) && (stepUnchanged.has(key) || explicitAll));
+      // apply through sealedModel so stepWrites/stepMutations record the commit
+      assigned.forEach(key => {
+        sealedModel[key] = nextDraft[key];
+      });
+    };
     const registerModelShape = shape => {
       modelShape = Object.assign(modelShape !== null && modelShape !== void 0 ? modelShape : {}, shape);
+      // v2 (#25): a declared shape in strict mode activates next-state semantics;
+      // expose next/unchanged to acceptors (absent in default mode and in strict
+      // instances without a modelShape, which keep in-place mutation). These
+      // stepApi entries are the unattributed (null-id) fallback — asAcceptor
+      // overrides them with each acceptor's id-bound pair
+      if (strict && !nextStateMode) {
+        nextStateMode = true;
+        stepApi.next = makeNextProxy(null);
+        stepApi.unchanged = makeUnchanged(null);
+      }
       // #29: the framework is immune to data keys shadowing Model methods, but
       // user code calling model.<key>() in render/naps would see data — flag it
       if (devWarnings) {
@@ -782,13 +984,20 @@
       } else if (writes.length > 0) {
         classification = 'identity-by-mutation';
       }
+      // v2 (#25): the primed view — the observable next-state relation for the step
+      const primed = {};
+      stepPrimed.forEach((value, key) => {
+        primed[key] = value;
+      });
       return {
         intent: currentIntentName,
         mutations,
         writes,
         rejections,
         classification,
-        deep: stepDeepChange
+        deep: stepDeepChange,
+        primed,
+        unchanged: stepUnchangedResolved.slice()
       };
     };
     const endStep = () => {
@@ -863,7 +1072,18 @@
       }, {}),
       acceptors: {
         keyed: acceptorRegistry.keyed.slice(),
-        broadcast: acceptorRegistry.broadcast
+        broadcast: acceptorRegistry.broadcast,
+        // v2 (#25): per-acceptor prime/frame view accumulated from execution —
+        // { primes, unchanged, unchangedAll } keyed by intent name ('*' for
+        // broadcast/array). Feeds the transpiler's UNCHANGED <<...>> clauses.
+        frames: Object.keys(acceptorMeta).reduce((acc, key) => {
+          acc[key] = {
+            primes: Array.from(acceptorMeta[key].primes),
+            unchanged: Array.from(acceptorMeta[key].unchanged),
+            unchangedAll: acceptorMeta[key].unchangedAll
+          };
+          return acc;
+        }, {})
       },
       modelShape: modelShape ? {
         ...modelShape
@@ -961,6 +1181,9 @@
         invokeModel('resetEventQueue');
         // accept proposal
         await Promise.all(acceptors.map(accept(proposal, stepApi)));
+
+        // v2 (#25): commit the next-state draft atomically after all acceptors
+        commitNextState(proposal);
         storeBehavior(proposal);
         endStep();
 
@@ -973,6 +1196,9 @@
         beginStep(proposal);
         // accept proposal (synchronously, so strict-profile errors propagate)
         acceptors.forEach(acceptSync(proposal, stepApi));
+
+        // v2 (#25): commit the next-state draft atomically after all acceptors
+        commitNextState(proposal);
         storeBehavior(proposal);
         endStep();
 
@@ -1022,7 +1248,7 @@
 
     // add one component at a time, returns array of intents from actions
     const addComponent = (component = {}) => {
-      var _intents;
+      var _intents, _component$localState;
       const {
         ignoreOutdatedProposals = false,
         debounce = 0,
@@ -1218,30 +1444,49 @@
       }
 
       // Add component's acceptors,  reactors, naps and safety condition to SAM instance
+      // v2 (#25): in next-state mode acceptors receive the frozen pre-state; each
+      // is wrapped with a distinct id so the draft can detect a variable primed by
+      // two acceptors. Reactors/naps keep the writable sealedModel (they own
+      // derived state, computed after commit).
+      const acceptorOperand = (_component$localState = component.localState) !== null && _component$localState !== void 0 ? _component$localState : nextStateMode ? frozenModel : sealedModel;
       if (component.acceptors && !Array.isArray(component.acceptors) && typeof component.acceptors === 'object') {
         // v2 (#23): keyed acceptor registration — the framework binds each
         // acceptor to its action, so acceptor bodies contain only guards and
-        // mutations; the switch-dispatch monolith is inexpressible in this form
+        // next-state assignments; the switch-dispatch monolith is inexpressible here
         Object.keys(component.acceptors).forEach(key => {
           const acceptorFactory = component.acceptors[key];
           if (key === '*') {
             // explicitly-marked cross-cutting (broadcast) acceptor
             acceptorRegistry.broadcast += 1;
-            mount(acceptors, [acceptorFactory], component.localState);
+            const id = nextAcceptorId++;
+            registerAcceptorMeta(id, '*');
+            mount(acceptors, [operand => {
+              const acceptor = acceptorFactory(operand);
+              return asAcceptor(id, (proposal, api) => acceptor(proposal, api));
+            }], acceptorOperand);
             return;
           }
           if (strict && intentRegistry[key] === undefined) {
             throw new Error("SAM: keyed acceptor '".concat(key, "' does not match any registered intent (declare the intent first, or use '*' for cross-cutting acceptors)"));
           }
           acceptorRegistry.keyed.push(key);
+          const id = nextAcceptorId++;
+          registerAcceptorMeta(id, key);
           mount(acceptors, [operand => {
             const acceptor = acceptorFactory(operand);
-            return (proposal, api) => proposal.__actionName === key ? acceptor(proposal, api) : undefined;
-          }], component.localState);
+            return asAcceptor(id, (proposal, api) => proposal.__actionName === key ? acceptor(proposal, api) : undefined);
+          }], acceptorOperand);
         });
       } else {
         acceptorRegistry.broadcast += A(component.acceptors).length;
-        mount(acceptors, component.acceptors, component.localState);
+        A(component.acceptors).forEach(acceptorFactory => {
+          const id = nextAcceptorId++;
+          registerAcceptorMeta(id, '*');
+          mount(acceptors, [operand => {
+            const acceptor = acceptorFactory(operand);
+            return asAcceptor(id, (proposal, api) => acceptor(proposal, api));
+          }], acceptorOperand);
+        });
       }
       mount(reactors, component.reactors, component.localState);
       mount(naps, rollback(component.safety), component.localState);


### PR DESCRIPTION
Brings `master` up to the sam-pattern 2.1.x era:

- **All 12 `v2/` samples migrated to the next-state (#25 / sam-lib#34) acceptor contract**: writes go to the `next` draft (`model` is the frozen pre-state), untouched variables framed via `unchanged(...)`, array/object variables assigned whole.
- **Vendored `v2/lib/SAM.js` at 2.1.2** (next-state + `SamFrameError` export + async-acceptor guard).
- **New permanent harness `tests/v2.test.js`** (15 tests): per-sample strict-error guard + one functional assertion each, deliberate-failure demos asserted positively (counter "Break it" must throw `SamSchemaError`, raft stale heartbeat must reject), and a vendor-drift guard that byte-compares the vendored lib against `sam-lib/dist`. `npm test` chains legacy (18) + v2 (15).

Gate: 33/33 green (18 legacy + 15 v2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)